### PR TITLE
Fix monaco lifecycle error when navigating back and forth.

### DIFF
--- a/openpectus/frontend/src/app/details/ngrx/details.reducer.ts
+++ b/openpectus/frontend/src/app/details/ngrx/details.reducer.ts
@@ -6,6 +6,7 @@ import { DetailsActions } from './details.actions';
 export const detailsFeatureKey = 'details';
 
 export interface DetailsState {
+  monacoServicesInitialized: boolean;
   methodEditorIsDirty: boolean;
   methodEditorContent?: string;
   processValues: ProcessValue[];
@@ -17,6 +18,7 @@ export interface DetailsState {
 }
 
 const initialState: DetailsState = {
+  monacoServicesInitialized: false,
   methodEditorIsDirty: false,
   processValues: [],
   processValuesLog: [],
@@ -27,6 +29,7 @@ const initialState: DetailsState = {
 
 export const detailsReducer = createReducer(initialState,
   on(DetailsActions.methodEditorInitialized, (state, {model}) => produce(state, draft => {
+    draft.monacoServicesInitialized = true;
     draft.methodEditorIsDirty = false;
     draft.methodEditorContent = model;
   })),

--- a/openpectus/frontend/src/app/details/ngrx/details.selectors.ts
+++ b/openpectus/frontend/src/app/details/ngrx/details.selectors.ts
@@ -6,6 +6,7 @@ import { detailsFeatureKey, DetailsState } from './details.reducer';
 
 export class DetailsSelectors {
   static selectFeature = createFeatureSelector<DetailsState>(detailsFeatureKey);
+  static monacoServicesInitialized = createSelector(this.selectFeature, state => state.monacoServicesInitialized);
   static methodEditorIsDirty = createSelector(this.selectFeature, state => state.methodEditorIsDirty);
   static methodEditorContent = createSelector(this.selectFeature, state => state.methodEditorContent);
   static processValues = createSelector(this.selectFeature, state => state.processValues);


### PR DESCRIPTION
Ensure monaco service initialization status is kept between lifecycle of method editor component.

Fixes lifecycle error in monaco when navigating back and forth.