### PR TITLE
Use the queue from queue instead of multiprocessing

### DIFF
--- a/openpectus/aggregator/aggregator.py
+++ b/openpectus/aggregator/aggregator.py
@@ -6,8 +6,8 @@ import openpectus.aggregator.models as Mdl
 import openpectus.protocol.aggregator_messages as AM
 import openpectus.protocol.engine_messages as EM
 import openpectus.protocol.messages as M
-from openpectus.aggregator.data.repository import RecentRunRepository, PlotLogRepository
 from openpectus.aggregator.data import database
+from openpectus.aggregator.data.repository import RecentRunRepository, PlotLogRepository
 from openpectus.aggregator.frontend_publisher import FrontendPublisher
 from openpectus.aggregator.models import EngineData
 from openpectus.protocol.aggregator_dispatcher import AggregatorDispatcher
@@ -58,14 +58,12 @@ class FromEngine:
 
         self._persist_tag_values(engine_data, plot_log_repo)
 
-    def _run_id_changed(self, plot_log_repo: PlotLogRepository, recent_run_repo: RecentRunRepository, engine_data: EngineData, run_id_tag: Mdl.TagValue):
+    def _run_id_changed(self, plot_log_repo: PlotLogRepository, recent_run_repo: RecentRunRepository, engine_data: EngineData,
+                        run_id_tag: Mdl.TagValue):
         """ Handles persistance related to start and end of a run """
-        logger.warning(f'run id changed to {run_id_tag.value}')
         if run_id_tag.value is None and engine_data.run_id is not None:
             # Run stopped
             recent_run_repo.store_recent_run(engine_data)
-            engine_data.run_data = Mdl.RunData()
-            # TODO: persist and clear from engine_map: method, run log,
         else:
             # Run started
             engine_data.run_data.run_started = datetime.fromtimestamp(run_id_tag.tick_time)

--- a/openpectus/engine/engine_reporter.py
+++ b/openpectus/engine/engine_reporter.py
@@ -87,6 +87,7 @@ class EngineReporter():
                 if tag_name is not None:
                     assert tag.tick_time is not None, f'tick_time is None for tag {tag.name}'
                     tags.append(Mdl.TagValue(name=tag_name, tick_time=tag.tick_time, value=tag.get_value(), value_unit=tag.unit))
+                self.engine.tag_updates.task_done()
         except Empty:
             pass
         if len(tags) > 0:
@@ -136,6 +137,6 @@ class EngineReporter():
         self.dispatcher.post(msg)
 
     def send_method_state(self):
-        state = self.engine.get_method_state()
+        state = self.engine.calculate_method_state()
         msg = EM.MethodStateMsg(method_state=state)
         self.dispatcher.post(msg)


### PR DESCRIPTION
to fix weird bugs where queue reported empty without being empty, and run_id change therefore coming very late and making it impossible for the aggregator to store the recent run before being wiped.