### PR TITLE
Fixed check for whether record node is PProgram

### DIFF
--- a/openpectus/engine/method_model.py
+++ b/openpectus/engine/method_model.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Callable
 from uuid import UUID
 from openpectus.lang.exec.runlog import RuntimeInfo
@@ -5,6 +6,7 @@ from openpectus.lang.grammar.pgrammar import PGrammar
 from openpectus.lang.model.pprogram import PNode, PProgram
 import openpectus.protocol.models as Mdl
 
+logger = logging.getLogger(__name__)
 
 def parse_pcode(pcode: str) -> PProgram:
     p = PGrammar()
@@ -68,7 +70,7 @@ class MethodModel():
         method_state = Mdl.MethodState.empty()
         if self._pcode != "":
             for record in runtimeinfo.records:
-                if record.node is not PProgram:
+                if not isinstance(record.node, PProgram):
                     assert record.node is not None, "node is None"
                     assert record.node.line is not None, "node.line is None, node: " + str(record.node)
                     line_num = record.node.line


### PR DESCRIPTION
When calculating method state. To avoid marking first line as started and executed twice.