### PR TITLE
Add method forwarding to hardware error decorator to support UOD comm…

### DIFF
--- a/openpectus/engine/hardware_recovery.py
+++ b/openpectus/engine/hardware_recovery.py
@@ -109,7 +109,7 @@ class ErrorRecoveryDecorator(HardwareLayerBase):
         try:
             self._setup_decorated_method_forwards()
         except Exception:
-            logger.error("Error setting up hardware base method forwards", exc_info=True)
+            logger.error("Error setting up decorated hardware method forwards", exc_info=True)
 
     def get_recovery_state(self) -> ErrorRecoveryState:
         return self.state

--- a/openpectus/engine/hardware_recovery.py
+++ b/openpectus/engine/hardware_recovery.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+import inspect
 import logging
 import time
 from typing import Any, Callable, Sequence
@@ -105,6 +106,11 @@ class ErrorRecoveryDecorator(HardwareLayerBase):
             self.state = ErrorRecoveryState.OK
             self.on_ok()
 
+        try:
+            self._setup_decorated_method_forwards()
+        except Exception:
+            logger.error("Error setting up hardware base method forwards", exc_info=True)
+
     def get_recovery_state(self) -> ErrorRecoveryState:
         return self.state
 
@@ -207,7 +213,6 @@ class ErrorRecoveryDecorator(HardwareLayerBase):
             self.reconnected_callback()
 
     # Decorator impl
-
 
     def read(self, r: Register) -> Any:
         if RegisterDirection.Read not in r.direction:
@@ -315,18 +320,6 @@ class ErrorRecoveryDecorator(HardwareLayerBase):
             for value, r in zip(values, registers):
                 self.pending_writes[r] = value
 
-    def _write_pending_values(self, except_names: list[str] = []):
-        if self.state == ErrorRecoveryState.OK and len(self.pending_writes) > 0:
-            pending_items = list(self.pending_writes.items())
-            for register, value in pending_items:
-                if register.name in except_names:
-                    continue
-                try:
-                    self.decorated.write(value, register)
-                    del self.pending_writes[register]
-                except HardwareLayerException:
-                    pass  # Better luck next time. We just had a success write so chances are good
-
     def connect(self):
         try:
             self.decorated.connect()
@@ -343,3 +336,40 @@ class ErrorRecoveryDecorator(HardwareLayerBase):
 
     def disconnect(self):
         return self.decorated.disconnect()
+
+    def _write_pending_values(self, except_names: list[str] = []):
+        if self.state == ErrorRecoveryState.OK and len(self.pending_writes) > 0:
+            pending_items = list(self.pending_writes.items())
+            for register, value in pending_items:
+                if register.name in except_names:
+                    continue
+                try:
+                    self.decorated.write(value, register)
+                    del self.pending_writes[register]
+                except HardwareLayerException:
+                    pass  # Better luck next time. We just had a success write so chances are good
+
+    def _setup_decorated_method_forwards(self):
+        """ Set up method forwards to avoid the decorator breaking commands that are implemented as methods
+            on the concrete hardware
+        """
+        def callable_publics_predicate(member):
+            if not inspect.ismethod(member) and not inspect.isfunction(member):
+                return False
+            if (name := getattr(member, "__name__", None)) is not None:
+                if name.startswith("__"):
+                    return False
+            return True
+
+        decorated_members = inspect.getmembers_static(self.decorated, callable_publics_predicate)
+        self_member_names = [member[0] for member in inspect.getmembers_static(self, callable_publics_predicate)]
+        for member in decorated_members:
+            name: str = member[0]
+            if name not in self_member_names:
+                logger.info(f"Forwarding method {name} from hardware class {type(self.decorated).__name__} to decorator")
+                func = member[1]
+
+                # define local method that forwards calls to func using self.decorated as its self
+                def caller(*args, **kvargs):
+                    return func(self.decorated, *args, **kvargs)
+                setattr(self, name, caller)

--- a/openpectus/engine/main.py
+++ b/openpectus/engine/main.py
@@ -7,7 +7,7 @@ from openpectus import log_setup_colorlog, sentry
 from openpectus.engine.engine import Engine
 from openpectus.engine.engine_message_handlers import EngineMessageHandlers
 from openpectus.engine.engine_reporter import EngineReporter
-import openpectus.engine.hardware_error as hardware_error
+from openpectus.engine.hardware_recovery import ErrorRecoveryConfig, ErrorRecoveryDecorator
 from openpectus.lang.exec.tags import SystemTagName, TagCollection
 from openpectus.lang.exec.uod import UnitOperationDefinitionBase
 from openpectus.protocol.engine_dispatcher import EngineDispatcher, EngineDispatcherBase
@@ -70,9 +70,9 @@ async def main_async(args):
 
     # wrap hwl with error recovery decorator
     connection_status_tag = engine._system_tags[SystemTagName.CONNECTION_STATUS]
-    uod.hwl = hardware_error.ErrorRecoveryDecorator(uod.hwl, hardware_error.ErrorRecoveryConfig(), connection_status_tag)
+    uod.hwl = ErrorRecoveryDecorator(uod.hwl, ErrorRecoveryConfig(), connection_status_tag)
 
-    # wrap dispatcher in error recovery decorator
+    # wrap dispatcher with error recovery decorator
     dispatcher = EngineDispatcherErrorRecoveryDecorator(dispatcher)
 
     reporter = EngineReporter(engine, dispatcher)

--- a/openpectus/test/engine/test_hardware.py
+++ b/openpectus/test/engine/test_hardware.py
@@ -10,7 +10,7 @@ from openpectus.engine.hardware import (
     Register,
     RegisterDirection,
 )
-from openpectus.engine.hardware_error import (
+from openpectus.engine.hardware_recovery import (
     ErrorRecoveryConfig,
     ErrorRecoveryDecorator,
     ErrorRecoveryState,
@@ -307,6 +307,11 @@ class TestHardwareErrorRecovery(unittest.TestCase):
         self.assertEqual(hwl.reg_A, decorator.registers["A"])
         self.assertEqual(len(hwl.registers), len(decorator.registers))
 
+    def test_methods_are_delegated(self):
+        decorator, hwl = self.create_hardwares()
+        # Since test hardware has this method, it should also be callable on the decorator. This is done using
+        # method forwarding, implemented in ErrorRecoveryDecorator._setup_base_method_forwards()
+        decorator.test_cmd()  # type: ignore
 
 class ErrorTestHardware(HardwareLayerBase):
     """ A test hardware class that can fail its operations when so directed by the test"""
@@ -324,6 +329,9 @@ class ErrorTestHardware(HardwareLayerBase):
         self.reg_A_value = 0
         self.reg_B_value = 0
         self.reg_C_value = 0
+
+    def test_cmd(self):
+        print("Test Cmd executed")
 
     def read(self, r: Register) -> Any:
         if self.read_fail:


### PR DESCRIPTION
…ands that are implemented as methods on a concrete hardware (like DemoHardware)

Rename hardware_error to hardware_recovery