### PR TITLE
Info, Warning and Error instructions

### DIFF
--- a/openpectus/aggregator/command_examples.py
+++ b/openpectus/aggregator/command_examples.py
@@ -90,12 +90,11 @@ Block: Layer 1
         End blocks
 # We have escaped both blocks.
 """),
-#     CommandExample(name="Error", example="""
-# # Make a statement to the log file.
-# # Does not output into the Runlog.
+    CommandExample(name="Error", example="""
+# Make a statement to the log file.
 
-# Error: Hello.
-# """),
+Error: Hello.
+"""),
     CommandExample(name="Hold", example="""
 # Hold current output values but do not
 # progress with respect to time.
@@ -119,12 +118,11 @@ Increment run counter
 
 Restart
 """),
-#     CommandExample(name="Info", example="""
-# # Make a statement to the log file.
-# # Does not output into the Runlog.
+    CommandExample(name="Info", example="""
+# Make a statement to the log file.
 
-# Info: Hello.
-# """),
+Info: Hello.
+"""),
     CommandExample(name="Mark", example="""
 # Make a note in the data file at the current point in time.
 
@@ -181,12 +179,11 @@ Outlet: VA38
 Wait: 1 min
 Outlet: VA37
 """),
-#     CommandExample(name="Warning", example="""
-# # Make a statement to the log file.
-# # Does not output into the Runlog.
+    CommandExample(name="Warning", example="""
+# Make a statement to the log file.
 
-# Warning: Hello.
-# """),
+Warning: Hello.
+"""),
     CommandExample(name="Watch", example="""
 # Watch is a block that executes when a condition is satisfied.
 

--- a/openpectus/engine/engine.py
+++ b/openpectus/engine/engine.py
@@ -253,7 +253,7 @@ class Engine(InterpreterContext):
 
     def tick(self, tick_time: float, increment_time: float):
         """ Performs a scan cycle tick. """
-        logger.debug(f"Tick {self._tick_number + 1}")
+        # logger.debug(f"Tick {self._tick_number + 1}")
 
         if not self._running:
             self._tick_timer.stop()
@@ -452,13 +452,14 @@ class Engine(InterpreterContext):
         # no engine command is running - start one
         try:
             command = create_internal_command(cmd_request.name)
-            if cmd_request.kvargs is not None:
+            args = cmd_request.get_args()
+            if args is not None:
                 try:
-                    command.init_args(cmd_request.kvargs)
-                    logger.debug(f"Initialized command {cmd_request.name} with arguments {cmd_request.kvargs}")
+                    command.init_args(args)
+                    logger.debug(f"Initialized command {cmd_request.name} with arguments {args}")
                 except Exception:
                     raise EngineError(
-                        f"Failed to initialize arguments '{cmd_request.kvargs}' for command '{cmd_request.name}'",
+                        f"Failed to initialize arguments '{args}' for command '{cmd_request.name}'",
                         "same"
                     )
 

--- a/openpectus/engine/internal_commands_impl.py
+++ b/openpectus/engine/internal_commands_impl.py
@@ -156,6 +156,7 @@ class HoldEngineCommand(InternalEngineCommand):
             logger.debug("Resuming using Unhold")
             UnholdEngineCommand(self.engine)._run()
 
+
 class UnholdEngineCommand(InternalEngineCommand):
     def __init__(self, engine: Engine) -> None:
         super().__init__(EngineCommandEnum.UNHOLD)
@@ -290,3 +291,30 @@ class RestartEngineCommand(InternalEngineCommand):
             e._set_run_id("new")
             e._system_tags[SystemTagName.SYSTEM_STATE].set_value(SystemStateEnum.Running, e._tick_time)
             logger.info("Restarting engine complete")
+
+
+class InfoEngineCommand(InternalEngineCommand):
+    def __init__(self, engine: Engine) -> None:
+        super().__init__(EngineCommandEnum.INFO)
+
+    def _run(self):
+        msg = self.kvargs.get("unparsed_args")
+        logger.info(f"Info: {msg}")
+
+
+class WarningEngineCommand(InternalEngineCommand):
+    def __init__(self, engine: Engine) -> None:
+        super().__init__(EngineCommandEnum.WARNING)
+
+    def _run(self):
+        msg = self.kvargs.get("unparsed_args")
+        logger.warning(f"Warning: {msg}")
+
+
+class ErrorEngineCommand(InternalEngineCommand):
+    def __init__(self, engine: Engine) -> None:
+        super().__init__(EngineCommandEnum.ERROR)
+
+    def _run(self):
+        msg = self.kvargs.get("unparsed_args")
+        logger.error(f"Error: {msg}")

--- a/openpectus/engine/main.py
+++ b/openpectus/engine/main.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from argparse import ArgumentParser, BooleanOptionalAction
 import importlib
+from os import path
+import pathlib
 from typing import Literal
 
 
@@ -19,12 +21,24 @@ log_setup_colorlog()
 
 StateKind = Literal["Started", "Connected", "Disconnected", "Reconnecting", "Reconnected"]
 
+file_handler = logging.FileHandler(filename=path.join(pathlib.Path(__file__).parent.resolve(), 'openpectus-engine.log'))
+file_handler.setLevel(logging.INFO)
+file_handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s]: %(message)s', datefmt='%Y-%m-%d %H:%M:%S'))
+
 logger = logging.getLogger("openpectus.engine.engine")
 logger.setLevel(logging.INFO)
+logger.addHandler(file_handler)
+
 logging.getLogger("openpectus.lang.exec.pinterpreter").setLevel(logging.INFO)
+logging.getLogger("openpectus.lang.exec.pinterpreter").addHandler(file_handler)
 logging.getLogger("openpectus.protocol.engine_dispatcher").setLevel(logging.DEBUG)
+logging.getLogger("openpectus.protocol.engine_dispatcher").addHandler(file_handler)
 logging.getLogger("openpectus.engine.engine_runner").setLevel(logging.INFO)
+logging.getLogger("openpectus.engine.engine_runner").addHandler(file_handler)
+logging.getLogger("openpectus.engine.internal_commands_impl").setLevel(logging.INFO)
+logging.getLogger("openpectus.engine.internal_commands_impl").addHandler(file_handler)
 logging.getLogger("asyncua.client").setLevel(logging.WARNING)
+
 
 def get_args():
     parser = ArgumentParser("Start Pectus Engine")

--- a/openpectus/engine/models.py
+++ b/openpectus/engine/models.py
@@ -14,6 +14,9 @@ class EngineCommandEnum(StrEnum):
     UNHOLD = "Unhold"
     WAIT = "Wait"
     RESTART = "Restart"
+    INFO = "Info"
+    WARNING = "Warning"
+    ERROR = "Error"
 
     @staticmethod
     def has_value(value: str):

--- a/openpectus/lang/exec/commands.py
+++ b/openpectus/lang/exec/commands.py
@@ -47,7 +47,13 @@ class CommandRequest():
             return CommandRequest(name=name, source="@interpreter", exec_id=exec_id, kvargs=kvargs)
 
     def __str__(self) -> str:
-        return f"EngineCommand {self.name} | args: {str(self.kvargs)}"
+        return f"EngineCommand {self.name} | kvargs: {str(self.kvargs)} | unparsed_args: {self.unparsed_args}"
+
+    def get_args(self) -> dict[str, Any]:
+        if self.kvargs is None or (self.kvargs == {} and self.unparsed_args is not None):
+            return {"unparsed_args": self.unparsed_args}
+        else:
+            return self.kvargs
 
 
 # Represents command API towards interpreter

--- a/openpectus/lang/exec/pinterpreter.py
+++ b/openpectus/lang/exec/pinterpreter.py
@@ -523,7 +523,7 @@ class PInterpreter(PNodeVisitor):
             self.context.tags[SystemTagName.BASE].set_value(node.args, self._tick_time)
 
         elif node.name == InterpreterCommandEnum.INCREMENT_RUN_COUNTER:
-            run_counter = self.context.tags[SystemTagName.RUN_COUNTER]            
+            run_counter = self.context.tags[SystemTagName.RUN_COUNTER]
             rc_value = run_counter.as_number() + 1
             logger.debug(f"Run Counter incremented from {rc_value - 1} to {rc_value}")
             run_counter.set_value(rc_value, self._tick_time)
@@ -555,7 +555,7 @@ class PInterpreter(PNodeVisitor):
             # We do, however, provide the execution id to the context
             # so that it can update the runtime record appropriately.
             try:
-                logger.debug(f"Executing command '{str(node)}' via engine")
+                logger.debug(f"Executing command '{str(node)}' with args '{node.args}' via engine")
                 self.context.schedule_execution(
                     name=node.name,
                     exec_id=record.exec_id,

--- a/openpectus/test/engine/test_builder.py
+++ b/openpectus/test/engine/test_builder.py
@@ -963,6 +963,23 @@ Stop
         self.assertEqual(wait.duration.time, 2.0)
         self.assertEqual(wait.duration.unit, "h")
 
+    def test_info_warning_error(self):
+        p = build("""
+Info:foo
+Warning: bar
+Error: baz
+""")
+        program = p.build_model()
+        self.assertFalse(program.has_error(recursive=True))
+        [info, warning, error] = program.get_instructions()
+        assert isinstance(info, PCommand)
+        self.assertEqual(info.args, "foo")
+        assert isinstance(warning, PCommand)
+        self.assertEqual(warning.args, "bar")
+        assert isinstance(error, PCommand)
+        self.assertEqual(error.args, "baz")
+
+
     @unittest.skip("Need a better error concept for this to make sense")
     def test_program_errors(self):
         p = build(

--- a/openpectus/test/engine/test_engine_new.py
+++ b/openpectus/test/engine/test_engine_new.py
@@ -218,7 +218,7 @@ Mark: C
 
         with runner.run() as instance:
             instance.start()
-            self.assertEqual([], instance.engine.interpreter.get_marks())
+            self.assertEqual([], instance.marks)
             instance.run_until_event("method_end")
             self.assertEqual(['A', 'B', 'C'], instance.engine.interpreter.get_marks())
 
@@ -234,7 +234,7 @@ Stop
         with runner.run() as instance:
             instance.start()
             instance.run_until_event("stop")
-            self.assertEqual([], instance.engine.interpreter.get_marks())
+            self.assertEqual([], instance.marks)
 
 
     @unittest.skip("speed > 1 not implemented")
@@ -348,3 +348,15 @@ Mark: C
 
             instance.run_until_event("method_end")
             self.assertTrue(['A', 'B', 'C', 'I'] == instance.marks or ['A', 'B', 'I', 'C'] == instance.marks)
+
+    def test_info_warning_error(self):
+        pcode = """
+Info: foo
+Warning: bar
+Error: baz
+Stop
+"""
+        runner = EngineTestRunner(create_test_uod, pcode=pcode)
+        with runner.run() as instance:
+            instance.start()
+            instance.run_until_event("stop")


### PR DESCRIPTION
Add engine support for unparsed internal commands
Add commands Info, Warning, Error as internal engine commands Enable engine file logger
Enable examples for Info, Warning and Error instructions