### PR TITLE
Compare recent engines to all online engines (not only those user has…

### DIFF
--- a/openpectus/aggregator/routers/process_unit.py
+++ b/openpectus/aggregator/routers/process_unit.py
@@ -63,7 +63,8 @@ def get_unit(user_roles: UserRolesValue, unit_id: str, agg: Aggregator = Depends
 @router.get("/process_units")
 def get_units(user_roles: UserRolesValue, agg: Aggregator = Depends(agg_deps.get_aggregator)) -> List[Dto.ProcessUnit]:
     units: List[Dto.ProcessUnit] = []
-    for engine_data in agg.get_all_registered_engine_data():
+    all_engine_data = agg.get_all_registered_engine_data()
+    for engine_data in all_engine_data:
         if not has_access(engine_data, user_roles):
             continue
         unit = map_pu(engine_data)
@@ -74,7 +75,7 @@ def get_units(user_roles: UserRolesValue, agg: Aggregator = Depends(agg_deps.get
     for recent_engine in recent_engines:
         if not has_access(recent_engine, user_roles):
             continue
-        if recent_engine.engine_id not in [u.id for u in units]:
+        if recent_engine.engine_id not in [e.engine_id for e in all_engine_data]:
             unit = Dto.ProcessUnit(
                 id=recent_engine.engine_id or "(error)",
                 name=recent_engine.name,


### PR DESCRIPTION
… access to) to avoid showing offline engine when it is online and user doesn't have access.