### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -12,65 +12,14 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   SHOULD_PUBLISH_IMAGE: ${{ github.ref == 'refs/heads/main' }}  
-  IS_PR: ${{ startsWith(github.ref, 'refs/pull/') }}  
-  IS_MAIN: ${{ startsWith(github.ref, 'refs/heads/main') }}  
   NODE_VERSION: 22.11 # 22.12 has incompatibilities https://github.com/nodejs/node/issues/56155 https://github.com/tailwindlabs/tailwindcss/pull/15421 due to https://nodejs.org/en/blog/release/v22.12.0#requireesm-is-now-enabled-by-default
 
 jobs:
 
-  one:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "$JOB_CONTEXT"
-      - name: Dump steps context
-        env:
-          STEPS_CONTEXT: ${{ toJson(steps) }}
-        run: echo "$STEPS_CONTEXT"
-      - name: Dump runner context
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-        run: echo "$RUNNER_CONTEXT"
-      - name: Dump strategy context
-        env:
-          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-        run: echo "$STRATEGY_CONTEXT"
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: echo "$MATRIX_CONTEXT"
-
-      - name: Show default environment variables
-        run: |
-          echo "The job_id is: $GITHUB_JOB"   # reference the default environment variables
-          echo "The id of this action is: $GITHUB_ACTION"   # reference the default environment variables
-          echo "The run id is: $GITHUB_RUN_ID"
-          echo "The GitHub Actor's username is: $GITHUB_ACTOR"
-          echo "GitHub SHA: $GITHUB_SHA"
-
-  pr:
-    runs-on: ubuntu-latest
-    if: ${{ ! vars.SHOULD_PUBLISH_IMAGE }}
-#    if: ${{ env.IS_PR }}
-    steps:
-      - name: PR info
-        run: echo Is pull request
-
-  notpr:
-    runs-on: ubuntu-latest
-    if: ${{ vars.SHOULD_PUBLISH_IMAGE }}
-    steps:
-      - name: PR info
-        run: echo Is not pull request
-
   test_backend:
-    name: Unittest ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    # seems name is used as status - need to figure out how to rename or status check will fail
+    #name: Unittest ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    name: test_backend
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -125,7 +74,9 @@ jobs:
             -d '{"event_type":"dispatch-event"}'
 
   build_frontend:
-    name: Build frontend
+    # seems name is used as status - need to figure out how to rename or status check will fail
+    #name: Build frontend
+    name: build_frontend
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +99,9 @@ jobs:
           path: "openpectus/frontend/dist"
 
   package_dist:
-    name: Build and Package
+    # seems name is used as status - need to figure out how to rename or status check will fail
+    #name: Build and Package
+    name: package_dist
     runs-on: ubuntu-22.04
     needs: [build_frontend, test_backend]
     steps:

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -195,6 +195,7 @@ jobs:
     needs: [package_dist]
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    if: ${{ vars.SHOULD_PUBLISH_IMAGE }}
     environment:
       name: pypi
       url: https://pypi.org/p/open-pectus
@@ -219,6 +220,7 @@ jobs:
     name: Publish Docker image
     needs: [package_dist]
     runs-on: ubuntu-latest
+    if: ${{ vars.SHOULD_PUBLISH_IMAGE }}
     permissions:
       packages: write
       contents: read
@@ -261,6 +263,7 @@ jobs:
     name: Deploy Docker image on Azure and Digital Ocean
     needs: [publish_docker_image]
     runs-on: ubuntu-latest
+    if: ${{ vars.SHOULD_PUBLISH_IMAGE }}
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -57,13 +57,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ $IS_PR }}
     steps:
-      run: echo Is pull request
+      - name: PR info
+        run: echo Is pull request
 
   notpr:
     runs-on: ubuntu-latest
     if: ${{ ! $IS_PR }}
     steps:
-      run: echo Is not pull request
+      - name: PR info
+        run: echo Is not pull request
 
   test_backend:
     name: Unittest ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -12,6 +12,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   SHOULD_PUBLISH_IMAGE: ${{ github.ref == 'refs/heads/main' }}
+  IS_PR: ${{ ! github.ref == 'refs/heads/main' }}
   NODE_VERSION: 22.11 # 22.12 has incompatibilities https://github.com/nodejs/node/issues/56155 https://github.com/tailwindlabs/tailwindcss/pull/15421 due to https://nodejs.org/en/blog/release/v22.12.0#requireesm-is-now-enabled-by-default
 
 jobs:
@@ -22,9 +23,7 @@ jobs:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
-          echo "$SHOULD_PUBLISH_IMAGE"
+        run: echo "$GITHUB_CONTEXT"
       - name: Dump job context
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
@@ -54,6 +53,12 @@ jobs:
           echo "The GitHub Actor's username is: $GITHUB_ACTOR"
           echo "GitHub SHA: $GITHUB_SHA"
 
+  pr:
+    if: ${{ $IS_PR }}
+    run: echo Is pull request
+  notpr:
+    if: ${{ ! $IS_PR }}
+    run: echo Is not pull request
 
   test_backend:
     name: Unittest ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -15,6 +15,45 @@ env:
   NODE_VERSION: 22.11 # 22.12 has incompatibilities https://github.com/nodejs/node/issues/56155 https://github.com/tailwindlabs/tailwindcss/pull/15421 due to https://nodejs.org/en/blog/release/v22.12.0#requireesm-is-now-enabled-by-default
 
 jobs:
+
+  one:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+        run: echo "$SHOULD_PUBLISH_IMAGE"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+
+      - name: Show default environment variables
+        run: |
+          echo "The job_id is: $GITHUB_JOB"   # reference the default environment variables
+          echo "The id of this action is: $GITHUB_ACTION"   # reference the default environment variables
+          echo "The run id is: $GITHUB_RUN_ID"
+          echo "The GitHub Actor's username is: $GITHUB_ACTOR"
+          echo "GitHub SHA: $GITHUB_SHA"
+
+
   test_backend:
     name: Unittest ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -55,14 +55,14 @@ jobs:
 
   pr:
     runs-on: ubuntu-latest
-    if: ${{ $IS_PR }}
+    if: ${{ IS_PR }}
     steps:
       - name: PR info
         run: echo Is pull request
 
   notpr:
     runs-on: ubuntu-latest
-    if: ${{ ! $IS_PR }}
+    if: ${{ ! IS_PR }}
     steps:
       - name: PR info
         run: echo Is not pull request

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -54,11 +54,16 @@ jobs:
           echo "GitHub SHA: $GITHUB_SHA"
 
   pr:
+    runs-on: ubuntu-latest
     if: ${{ $IS_PR }}
-    run: echo Is pull request
+    steps:
+      run: echo Is pull request
+
   notpr:
+    runs-on: ubuntu-latest
     if: ${{ ! $IS_PR }}
-    run: echo Is not pull request
+    steps:
+      run: echo Is not pull request
 
   test_backend:
     name: Unittest ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-        run: echo "$SHOULD_PUBLISH_IMAGE"
+        run: |
+          echo "$GITHUB_CONTEXT"
+          echo "$SHOULD_PUBLISH_IMAGE"
       - name: Dump job context
         env:
           JOB_CONTEXT: ${{ toJson(job) }}

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -54,6 +54,12 @@ jobs:
         run: |
           cd openpectus
           python -m unittest
+  
+  validate_uods:
+    name: Validate UODs in Closed-Pectus repository
+    needs: [test_backend]
+    runs-on: ubuntu-latest
+    steps:
       - name: Trigger validation of UODs in Closed-Pectus repository
         run: |
           curl -L \

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -56,7 +56,7 @@ jobs:
 
   pr:
     runs-on: ubuntu-latest
-    if: ${{ ! env.SHOULD_PUBLISH_IMAGE }}
+    if: ${{ ! vars.SHOULD_PUBLISH_IMAGE }}
 #    if: ${{ env.IS_PR }}
     steps:
       - name: PR info
@@ -64,7 +64,7 @@ jobs:
 
   notpr:
     runs-on: ubuntu-latest
-    if: ${{ env.SHOULD_PUBLISH_IMAGE }}
+    if: ${{ vars.SHOULD_PUBLISH_IMAGE }}
     steps:
       - name: PR info
         run: echo Is not pull request

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -11,8 +11,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  SHOULD_PUBLISH_IMAGE: ${{ github.ref == 'refs/heads/main' }}
-  IS_PR: ${{ ! github.ref == 'refs/heads/main' }}
+  SHOULD_PUBLISH_IMAGE: ${{ github.ref == 'refs/heads/main' }}  
+  IS_PR: ${{ startsWith(github.ref, 'refs/pull/') }}  
+  IS_MAIN: ${{ startsWith(github.ref, 'refs/heads/main') }}  
   NODE_VERSION: 22.11 # 22.12 has incompatibilities https://github.com/nodejs/node/issues/56155 https://github.com/tailwindlabs/tailwindcss/pull/15421 due to https://nodejs.org/en/blog/release/v22.12.0#requireesm-is-now-enabled-by-default
 
 jobs:
@@ -55,14 +56,14 @@ jobs:
 
   pr:
     runs-on: ubuntu-latest
-    if: ${{ IS_PR }}
+    if: ${{ env.IS_PR }}
     steps:
       - name: PR info
         run: echo Is pull request
 
   notpr:
     runs-on: ubuntu-latest
-    if: ${{ ! IS_PR }}
+    if: ${{ ! env.IS_PR }}
     steps:
       - name: PR info
         run: echo Is not pull request

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -15,21 +15,23 @@ env:
   NODE_VERSION: 22.11 # 22.12 has incompatibilities https://github.com/nodejs/node/issues/56155 https://github.com/tailwindlabs/tailwindcss/pull/15421 due to https://nodejs.org/en/blog/release/v22.12.0#requireesm-is-now-enabled-by-default
 
 jobs:
-
   test_backend:
-    runs-on: ubuntu-latest
+    name: Unittest ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-latest]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Install OpenPectus (as editable)
-        run: |
-          pip install -e '.[development]'
+        run: pip install -e '.[development]'
       - name: Lint with flake8
         run: |
           # use configuration from ./.flake8
@@ -39,6 +41,7 @@ jobs:
           # exit-zero treats all errors as warnings.
           #flake8 . --count --exit-zero --statistics
       - name: Lint with flake8 (warnings)
+        if: runner.os == 'Linux'
         run: |
           # use configuration from ./.flake8
           cd openpectus
@@ -46,15 +49,24 @@ jobs:
             echo "::warning::Flake8 Lint Warning"
           fi
       - name: Type check with pyright
-        run: |
-          pyright
+        run: pyright
       - name: Test with unittest
         run: |
           cd openpectus
           python -m unittest
+      - name: Trigger validation of UODs in Closed-Pectus repository
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.CLOSED_PECTUS_REPOSITORY_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/Open-Pectus/Closed-Pectus/dispatches \
+            -d '{"event_type":"dispatch-event"}'
 
   build_frontend:
-    runs-on: ubuntu-latest
+    name: Build frontend
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -76,7 +88,8 @@ jobs:
           path: "openpectus/frontend/dist"
 
   package_dist:
-    runs-on: ubuntu-latest
+    name: Build and Package
+    runs-on: ubuntu-22.04
     needs: [build_frontend, test_backend]
     steps:
       - uses: actions/checkout@v4
@@ -85,8 +98,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install openpectus python dependencies
-        run: |
-          python -m pip install --upgrade pip build
+        run: python -m pip install --upgrade pip build
       - name: Download frontend dist into aggregator
         uses: actions/download-artifact@v4
         with:
@@ -100,20 +112,18 @@ jobs:
         run: |
           echo "{\"build_number\": \"$build_number\", \"git_sha\": \"$git_sha\"}" > openpectus/build.json
           echo "Build number: $build_number"
-      - name: Build OpenPectus with frontend dist (package openpectus-x.y.z.tar.gz)
+      - name: Build Open Pectus with frontend dist (package openpectus-x.y.z.tar.gz)
         # build openpectus-x.y.z.tar.gz using version number defined in source (__version__ in __init__.py)
-        run: |
-          python -m build --sdist -o openpectus/dist
-      - name: Archive production bundle artifact
+        run: python -m build --sdist -o openpectus/dist
+      - name: Archive Open Pectus with frontend dist (version no.)
         uses: actions/upload-artifact@v4
         with:
           name: openpectus-dist-pypi
           path: openpectus/dist/*.tar.gz
       - name: Rename package to remove version number (openpectus.tar.gz)
         # rename package file openpectus-x.y.z.tar.gz to openpectus.tar.gz for a Dockerfile independent of version
-        run: |
-          mv openpectus/dist/openpectus-*.tar.gz openpectus/dist/openpectus.tar.gz
-      - name: Archive production bundle artifact
+        run: mv openpectus/dist/openpectus-*.tar.gz openpectus/dist/openpectus.tar.gz
+      - name: Archive Open Pectus with frontend dist for Docker
         uses: actions/upload-artifact@v4
         with:
           name: openpectus-dist
@@ -146,6 +156,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   publish_docker_image:
+    name: Publish Docker image
     needs: [package_dist]
     runs-on: ubuntu-latest
     permissions:
@@ -185,18 +196,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           context: .
           file: ./Dockerfile
-      # https://docs.digitalocean.com/reference/api/api-reference/#operation/apps_create_deployment
-      - name: Trigger deployment in Digital Ocean after push to Github container registry
-        run: |
-          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.DIGITALOCEAN_TOKEN }}" "https://api.digitalocean.com/v2/apps/${{ secrets.DIGITALOCEAN_APP_ID }}/deployments"
 
   deploy_image:
+    name: Deploy Docker image on Azure and Digital Ocean
     needs: [publish_docker_image]
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
     steps:
+      # https://docs.digitalocean.com/reference/api/api-reference/#operation/apps_create_deployment
+      - name: Trigger deployment in Digital Ocean after push to Github container registry
+        run: |
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.DIGITALOCEAN_TOKEN }}" "https://api.digitalocean.com/v2/apps/${{ secrets.DIGITALOCEAN_APP_ID }}/deployments"
       - name: 'Login via Azure CLI'
         uses: azure/login@v1
         with:

--- a/.github/workflows/combined-workflows.yml
+++ b/.github/workflows/combined-workflows.yml
@@ -56,14 +56,15 @@ jobs:
 
   pr:
     runs-on: ubuntu-latest
-    if: ${{ env.IS_PR }}
+    if: ${{ ! env.SHOULD_PUBLISH_IMAGE }}
+#    if: ${{ env.IS_PR }}
     steps:
       - name: PR info
         run: echo Is pull request
 
   notpr:
     runs-on: ubuntu-latest
-    if: ${{ ! env.IS_PR }}
+    if: ${{ env.SHOULD_PUBLISH_IMAGE }}
     steps:
       - name: PR info
         run: echo Is not pull request

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "openpectus"
 authors = [{name = "Eskild Schroll-Fleischer", email = "eyfl@novonordisk.com"}, {name = "Morten Passow Odgaard", email = "mpo@mjolner.dk"}, {name = "Jan H. Knudsen", email = "jhk@mjolner.dk"}]
 dynamic = ["version", "description"]
 readme = "README.md"
+requires-python = ">= 3.11, <=3.12"
 
 dependencies = [
     "antlr4-python3-runtime==4.13.1",
@@ -42,6 +43,7 @@ exclude = [
     "openpectus/engine/p1*",
     "openpectus/.flake8*",
     "openpectus/.idea*",
+    "openpectus/dist",
     "openpectus/Dockerfile",
     "openpectus/docker-compose.yml"
 ]


### PR DESCRIPTION
* Require specific Python version
* Do not package dist folder in distribution
* Run CI on Windows and Linux
* Support running CI on multiple Python versions
* Target specific Ubuntu 22.04
* Add step to trigger CI on Closed Pectus repository
* Linting

Personal Access Token for access to Closed-Pectus repository has been generated using @nneskildsf and is set to not expire.