### PR TITLE
Add support for daemon authentication flow via client secret.

### DIFF
--- a/openpectus/aggregator/routers/auth.py
+++ b/openpectus/aggregator/routers/auth.py
@@ -98,10 +98,11 @@ def user_roles(x_identity: Annotated[str, Header()] = "") -> set[str]:
         return set()
 
     token = decode_token_or_fail(x_identity)
-    # Return default role "Daemon" for authenticated applications
+    roles = set(token.get("roles") or [])
+    # Add default role "Daemon" for authenticated applications
     if token.get("idtyp", "") == "app":
-        return set(["Daemon"])
-    return set(token.get("roles") or [])
+        roles |= set(["Daemon"])
+    return roles
 
 
 UserRolesDependency = Security(user_roles)

--- a/openpectus/aggregator/routers/auth.py
+++ b/openpectus/aggregator/routers/auth.py
@@ -8,26 +8,30 @@ from fastapi import APIRouter, HTTPException, status
 from fastapi.params import Header, Security
 from openpectus.aggregator.routers.dto import AuthConfig
 
-router = APIRouter(tags=['auth'])
+router = APIRouter(tags=["auth"])
 
-# much in this file is based on https://alukach.com/posts/fastapi-rs256-jwt/
+# Much in this file is based on https://alukach.com/posts/fastapi-rs256-jwt/
+# Authentication is possible via PKCE flow or via client secret for daemon
+# applications.
+# Remember to add optional claim "idtyp" on Azure App Registration -> Token configuration page.
 
-use_auth = os.getenv('ENABLE_AZURE_AUTHENTICATION', default='').lower() == 'true'
-tenant_id = os.getenv('AZURE_DIRECTORY_TENANT_ID', default=None)
-authority_url = f'https://login.microsoftonline.com/{tenant_id}/v2.0' if tenant_id else None
-well_known_url = f'{authority_url}/.well-known/openid-configuration' if authority_url else None
-client_id = os.getenv('AZURE_APPLICATION_CLIENT_ID', default=None)
-# token_url = f'https://login.microsoftonline.com/{tenant_id}/oauth2/token'
-# authorization_url = f'https://login.microsoftonline.com/{tenant_id}/oauth2/authorize'
-jwks_url = 'https://login.microsoftonline.com/common/discovery/keys'
+use_auth = os.getenv("ENABLE_AZURE_AUTHENTICATION", default="").lower() == "true"
+tenant_id = os.getenv("AZURE_DIRECTORY_TENANT_ID", default=None)
+client_id = os.getenv("AZURE_APPLICATION_CLIENT_ID", default=None)
+authority_url = f"https://login.microsoftonline.com/{tenant_id}/v2.0" if tenant_id else None
+well_known_url = f"{authority_url}/.well-known/openid-configuration" if tenant_id else None
+jwks_url_id_token = "https://login.microsoftonline.com/common/discovery/keys"
+jwks_url_access_token = f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys" if tenant_id else ""
+access_token_issuer = f"https://sts.windows.net/{tenant_id}/" if tenant_id else ""
 
 if use_auth:
     print("Authentication enabled")
+    assert tenant_id is not None, "Assign Tenant ID to environment variable AZURE_DIRECTORY_TENANT_ID"
+    assert client_id is not None, "Assign Client ID to environment variable AZURE_APPLICATION_CLIENT_ID"
 else:
     print("Authentication disabled")
 
-
-@router.get('/config')
+@router.get("/config")
 def get_config() -> AuthConfig:
     return AuthConfig(
         use_auth=use_auth,
@@ -36,49 +40,71 @@ def get_config() -> AuthConfig:
         well_known_url=well_known_url
     )
 
-# oauth2_scheme = security.OAuth2AuthorizationCodeBearer(
-#     authorizationUrl=authorization_url,
-#     tokenUrl=token_url,
-# )
 
+# PKCE and client secret flows use different keys:
+jwks_client_pkce = jwt.PyJWKClient(jwks_url_id_token)
+jwks_client_secret = jwt.PyJWKClient(jwks_url_access_token)
 
-jwks_client = jwt.PyJWKClient(jwks_url)
 
 def decode_token_or_fail(x_identity) -> dict[str, Any]:
+    # Bearer tokens from PKCE flow result in an ID token.
+    # Bearer tokens from secret flow result in access token.
+    # Try to parse either one. Raise exception if neither
+    # can be validated.
     try:
-        token: dict[str, str | list[str]] = jwt.decode(
-                x_identity,
-                jwks_client.get_signing_key_from_jwt(x_identity).key,
-                algorithms=["RS256"],
-                audience=client_id,
-                issuer=authority_url
-            )
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate id token in X-Identity header",
-            headers={"WWW-Authenticate": "Bearer"},
-        ) from e
-    return token
+        id_token: dict[str, str | list[str]] = jwt.decode(
+            x_identity,
+            jwks_client_pkce.get_signing_key_from_jwt(x_identity).key,
+            algorithms=["RS256"],
+            audience=client_id,
+            issuer=authority_url
+        )
+        return id_token
+    except jwt.PyJWTError:
+        pass
+
+    try:
+        access_token: dict[str, str | list[str]] = jwt.decode(
+            x_identity,
+            jwks_client_secret.get_signing_key_from_jwt(x_identity),
+            algorithms=["RS256"],
+            audience=client_id,
+            issuer=access_token_issuer
+        )
+        return access_token
+    except jwt.PyJWTError:
+        pass
+    # If we got this far, then we couldn't validate the token in either case
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate token in X-Identity header",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
-def user_name(x_identity: Annotated[str, Header()] = '') -> str:
+def user_name(x_identity: Annotated[str, Header()] = "") -> str:
     if not use_auth:
         return "Anon"
 
     token = decode_token_or_fail(x_identity)
+    # Return default name "Daemon" for authenticated applications
+    if token.get("idtyp", "") == "app":
+        return "Daemon"
     preferred_username = token.get("preferred_username", "")  # email address, field 'name' has full name
     if "@" in preferred_username:
         preferred_username = preferred_username[0: preferred_username.index("@")]
     return str(preferred_username).upper()
 
 
-def user_roles(x_identity: Annotated[str, Header()] = '') -> set[str]:
+def user_roles(x_identity: Annotated[str, Header()] = "") -> set[str]:
     if not use_auth:
         return set()
 
     token = decode_token_or_fail(x_identity)
-    return set(token.get('roles') or [])
+    # Return default role "Daemon" for authenticated applications
+    if token.get("idtyp", "") == "app":
+        return set(["Daemon"])
+    return set(token.get("roles") or [])
 
 
 UserRolesDependency = Security(user_roles)


### PR DESCRIPTION
A terminal application can authenticate with an `access_token` (id tokens are not available for terminal applications). Terminal applications are defined to have the role and name `Daemon`. It is then up to the UOD authors to decide if the `Daemon` role should have access to their UOD.

An example terminal application which can get a list of `recent_runs` is given below:
```python
# pip install msal PyJWT requests
import msal
import jwt
import requests


def acquire_access_token(client_id: str,
                         tenant_id: str,
                         client_secret: str) -> str:
    """
    Acquire Access Token using Daemon Client Secret flow.
    """
    # Configure URLs.
    authority = f"https://login.microsoftonline.com/{tenant_id}"
    issuer_url = f"https://sts.windows.net/{tenant_id}/"
    jwks_url = f"{authority}/discovery/v2.0/keys"
    # Configure scope
    scopes = [f"{client_id}/.default",]

    msal_result = msal.ConfidentialClientApplication(
        client_id,
        authority=authority,
        client_credential=client_secret
    ).acquire_token_for_client(scopes=scopes)

    access_token = msal_result.get("access_token", None)  # type: ignore
    if access_token is None:
        raise Exception("Authentication was not successful.")

    # Verify that key is any good
    access_token_dict: dict[str, str | list[str]] = jwt.decode(
        access_token,
        jwt.PyJWKClient(jwks_url).get_signing_key_from_jwt(access_token),
        algorithms=["RS256"],
        audience=client_id,
        issuer=issuer_url,
    )
    return access_token


access_token = acquire_access_token(
    client_id="...",
    tenant_id="...",
    client_secret="...",
)
print(access_token)

recent_runs = requests.get(
    ".../api/recent_runs/",
    headers={"X-Identity": access_token,},
)
print(recent_runs, recent_runs.json())
```

Terminal application access would primarily be used to periodically download data from recent runs, although it could also be used for more sophisticated purposes.