### PR TITLE
Generate example code for with process value choice during validation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,7 +86,7 @@ All the following commands can only be run from within the (mini)conda prompt, a
 
 Create a new conda environment and install all dependencies:
 ```shell
-conda env create -p=./conda --file=environment.yml
+conda env create --prefix=./conda --file=environment.yml
 ```
 
 Activate the created pectus conda environment:

--- a/openpectus/engine/main.py
+++ b/openpectus/engine/main.py
@@ -5,7 +5,7 @@ import importlib.util
 from logging.handlers import RotatingFileHandler
 from os import path
 import pathlib
-from typing import Literal, Tuple
+from typing import Literal
 from itertools import chain
 
 
@@ -219,8 +219,7 @@ def run_example_commands(uod: UnitOperationDefinitionBase):
     logger.info("Validating UOD command examples")
     uod.hwl = NullHardware()
 
-    def run_example_with_description(arg: Tuple[str, str]):
-        description, example = arg
+    def run_example_with_description(description: str, example: str) -> list[str]:
         failed_cmds: list[str] = []
         try:
             runner = EngineTestRunner(uod_factory=lambda: uod, pcode=example)
@@ -237,12 +236,12 @@ def run_example_commands(uod: UnitOperationDefinitionBase):
 
     logger.info("Executing example commands")
     failed_cmds: list[str] = list(
-        chain.from_iterable(
-            map(
-                run_example_with_description,
-                uod.generate_pcode_examples()
-            )
+      chain.from_iterable(
+        map(
+            lambda t: run_example_with_description(t[0], t[1]),
+            uod.generate_pcode_examples()
         )
+      )
     )
 
     if len(failed_cmds) > 0:

--- a/openpectus/engine/main.py
+++ b/openpectus/engine/main.py
@@ -5,7 +5,8 @@ import importlib.util
 from logging.handlers import RotatingFileHandler
 from os import path
 import pathlib
-from typing import Literal
+from typing import Literal, Tuple
+from itertools import chain
 
 
 from openpectus import log_setup_colorlog, sentry, __version__, build_number
@@ -208,43 +209,37 @@ def validate_and_exit(uod_name: str):
     logger.info("Validation complete. Exiting.")
     exit(0)
 
+
 def run_example_commands(uod: UnitOperationDefinitionBase):
     uod.build_commands()
     logger.info("Validating UOD command examples")
     uod.hwl = NullHardware()
 
-    failed_cmds: list[str] = []
-    for desc in uod.command_descriptions.values():
-        logger.info(f"Executing example commands for uod command '{desc.name}'")
-        pcode = desc.get_docstring_pcode()
-        if pcode.strip() == "":
-            logger.warning(f"Command '{desc.name} has no pcode example")
-            continue
+    def run_example_with_description(arg: Tuple[str, str]):
+        description, example = arg
+        failed_cmds: list[str] = []
         try:
-            runner = EngineTestRunner(uod_factory=lambda: uod, pcode=pcode)
+            runner = EngineTestRunner(uod_factory=lambda: uod, pcode=example)
             with runner.run() as instance:
                 instance.start()
-                # wait up to 1 minute, that oughta be enought for everybody
+                # wait up to 1 minute, that ought to be enought for everybody
                 instance.run_until_event("method_end", max_ticks=10*60)
                 logger.debug(instance.get_runtime_table())
-                logger.debug(f"Command '{pcode}' executed successfully")
+                logger.debug(f"{description} executed successfully")
         except Exception as ex:
-            logger.error(f"Command '{pcode}' failed: {str(ex)}")
-            failed_cmds.append(desc.name)
+            logger.error(f"{description} '{example}' failed: {str(ex)}")
+            failed_cmds.append(example)
+        return failed_cmds
 
-        examples = desc.generate_pcode_examples()
-        for example in examples:
-            try:
-                runner = EngineTestRunner(uod_factory=lambda: uod, pcode=example)
-                with runner.run() as instance:
-                    instance.start()
-                    # wait up to 1 minute, that oughta be enought for everybody
-                    instance.run_until_event("method_end", max_ticks=10*60)
-                    logger.debug(instance.get_runtime_table())
-                    logger.debug(f"Command '{desc.name}' executed successfully")
-            except Exception as ex:
-                logger.error(f"Command '{example}' failed: {str(ex)}")
-                failed_cmds.append(example)
+    logger.info("Executing example commands")
+    failed_cmds: list[str] = list(
+        chain.from_iterable(
+            map(
+                run_example_with_description,
+                uod.generate_pcode_examples()
+            )
+        )
+    )
 
     if len(failed_cmds) > 0:
         logger.error(f"Example commands failed: {','.join(failed_cmds)}")

--- a/openpectus/lang/exec/readings.py
+++ b/openpectus/lang/exec/readings.py
@@ -91,6 +91,9 @@ class Reading():
             ) for c in self.commands]
         )
 
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}({self.tag_name=})"
+
 class ReadingWithEntry(Reading):
     def __init__(
             self,
@@ -246,3 +249,6 @@ class UodCommandDescription:
                         arg = "+".join(args)
                         examples.append(f"{self.name}: {arg}")
         return examples
+
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.name=})"

--- a/openpectus/lang/exec/uod.py
+++ b/openpectus/lang/exec/uod.py
@@ -333,25 +333,29 @@ The execution function is missing named arguments or a '**kvargs' argument""")
     def validate_command_name(self, command_name: str) -> bool:
         return command_name in self.get_command_names()
 
-    def generate_pcode_examples(self) -> Generator[Tuple[str, str]]:
+    def generate_pcode_examples(self) -> list[Tuple[str, str]]:
+        """ Generate example code as tuples of (description, example_pcode). """
+        examples: list[Tuple[str, str]] = []
         for description in self.command_descriptions.values():
             # Generate example from command docstring
             docstring_pcode_example = description.get_docstring_pcode()
             if not docstring_pcode_example.strip():
                 logger.warning(f"{description} has no pcode example")
             else:
-                yield (str(description), docstring_pcode_example)
+                examples.append((str(description), docstring_pcode_example))
 
             # Generate examples from arg_parse_regex if RegexCategorical
             # or RegexNumber.
             for regex_example in description.generate_pcode_examples():
-                yield (str(description), regex_example)
+                examples.append((str(description), regex_example))
 
         # Generate examples from readings with command_options
         for reading in self.readings:
             if reading.command_options:
                 for command_option in reading.command_options.values():
-                    yield (str(reading), command_option)
+                    examples.append((str(reading), command_option))
+
+        return examples
 
 
 INIT_FN = Callable[[], None]

--- a/openpectus/lang/exec/uod.py
+++ b/openpectus/lang/exec/uod.py
@@ -333,6 +333,26 @@ The execution function is missing named arguments or a '**kvargs' argument""")
     def validate_command_name(self, command_name: str) -> bool:
         return command_name in self.get_command_names()
 
+    def generate_pcode_examples(self) -> Generator[Tuple[str, str]]:
+        for description in self.command_descriptions.values():
+            # Generate example from command docstring
+            docstring_pcode_example = description.get_docstring_pcode()
+            if not docstring_pcode_example.strip():
+                logger.warning(f"{description} has no pcode example")
+            else:
+                yield (str(description), docstring_pcode_example)
+
+            # Generate examples from arg_parse_regex if RegexCategorical
+            # or RegexNumber.
+            for regex_example in description.generate_pcode_examples():
+                yield (str(description), regex_example)
+
+        # Generate examples from readings with command_options
+        for reading in self.readings:
+            if reading.command_options:
+                for command_option in reading.command_options.values():
+                    yield (str(reading), command_option)
+
 
 INIT_FN = Callable[[], None]
 """ Command initialization method. """

--- a/openpectus/lang/exec/uod.py
+++ b/openpectus/lang/exec/uod.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from inspect import _ParameterKind, Parameter
 import logging
 import re
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, Generator, Tuple
 
 from openpectus.engine.commands import ContextEngineCommand, CommandArgs
 from openpectus.engine.hardware import HardwareLayerBase, NullHardware, Register, RegisterDirection


### PR DESCRIPTION
Refactor `run_example_commands` to generate the examples in the `uod` class and then run them in `run_example_commands`. This structure makes it easier to eventually parallelize execution of example commands.