### PR TITLE
Database path should be an argument to pectus aggregator

### DIFF
--- a/openpectus/Dockerfile
+++ b/openpectus/Dockerfile
@@ -3,11 +3,11 @@ FROM python:3.11
 # see https://hub.docker.com/_/python/
 
 WORKDIR /usr/src/app
-
+RUN mkdir -p /usr/src/app/data
 COPY dist ./dist/
 RUN pip install --no-cache-dir dist/openpectus.tar.gz
 
 ENV AGGREGATOR_PORT=8300
 
 EXPOSE $AGGREGATOR_PORT
-CMD pectus-aggregator --host 0.0.0.0 --port $AGGREGATOR_PORT
+CMD pectus-aggregator --host 0.0.0.0 --port $AGGREGATOR_PORT --database /usr/src/app/data/open_pectus_aggregator.sqlite3

--- a/openpectus/Dockerfile
+++ b/openpectus/Dockerfile
@@ -3,11 +3,11 @@ FROM python:3.13
 # see https://hub.docker.com/_/python/
 
 WORKDIR /usr/src/app
-RUN mkdir -p /usr/src/app/data
+RUN mkdir -p /data
 COPY dist ./dist/
 RUN pip install --no-cache-dir dist/openpectus.tar.gz
 
 ENV AGGREGATOR_PORT=8300
 
 EXPOSE $AGGREGATOR_PORT
-CMD pectus-aggregator --host 0.0.0.0 --port $AGGREGATOR_PORT --database /usr/src/app/data/open_pectus_aggregator.sqlite3
+CMD pectus-aggregator --host 0.0.0.0 --port $AGGREGATOR_PORT --database /data/open_pectus_aggregator.sqlite3

--- a/openpectus/aggregator/aggregator_server.py
+++ b/openpectus/aggregator/aggregator_server.py
@@ -5,6 +5,7 @@ import uvicorn
 from openpectus.aggregator.routers.auth import UserRolesDependency
 from fastapi import FastAPI, APIRouter
 from fastapi.routing import APIRoute
+from openpectus import __version__
 from openpectus.aggregator.aggregator_message_handlers import AggregatorMessageHandlers
 from openpectus.aggregator.data import database
 from openpectus.aggregator.deps import _create_aggregator
@@ -44,6 +45,9 @@ class AggregatorServer:
             return f"{route.name}"
 
         self.fastapi = FastAPI(title=self.title,
+                               version=__version__,
+                               contact=dict(name="Open Pectus",
+                                            url="https://github.com/Open-Pectus/Open-Pectus"),
                                generate_unique_id_function=custom_generate_unique_id,
                                on_shutdown=[self.on_shutdown])
         self.fastapi.include_router(process_unit.router, prefix=api_prefix, dependencies=[UserRolesDependency])

--- a/openpectus/aggregator/aggregator_server.py
+++ b/openpectus/aggregator/aggregator_server.py
@@ -16,9 +16,8 @@ from openpectus.protocol.aggregator_dispatcher import AggregatorDispatcher
 
 
 class AggregatorServer:
-    default_title = "Pectus Aggregator"
+    default_title = "Open Pectus Aggregator"
     default_frontend_dist_dir = os.path.join(os.path.dirname(__file__), "frontend-dist")
-    # default_frontend_dist_dir = ".\\openpectus\\frontend\\dist"
     default_host = "127.0.0.1"
     default_port = 9800
     default_db_filename = "open_pectus_aggregator.sqlite3"
@@ -31,6 +30,8 @@ class AggregatorServer:
         self.port = port
         self.frontend_dist_dir = frontend_dist_dir
         self.db_path = db_path
+        if not os.path.exists(frontend_dist_dir):
+            raise FileNotFoundError("{frontend_dist_dir} not found.")
         self.dispatcher = AggregatorDispatcher()
         self.publisher = FrontendPublisher()
         self.aggregator = _create_aggregator(self.dispatcher, self.publisher)
@@ -52,11 +53,9 @@ class AggregatorServer:
                                on_shutdown=[self.on_shutdown])
         self.fastapi.include_router(process_unit.router, prefix=api_prefix, dependencies=[UserRolesDependency])
         self.fastapi.include_router(recent_runs.router, prefix=api_prefix, dependencies=[UserRolesDependency])
-        self.fastapi.include_router(auth.router, prefix='/auth')
+        self.fastapi.include_router(auth.router, prefix="/auth")
         for route in additional_routers:
             self.fastapi.include_router(route)
-        if not os.path.exists(self.frontend_dist_dir):
-            raise FileNotFoundError("frontend_dist_dir not found: " + self.frontend_dist_dir)
         self.fastapi.mount("/", SinglePageApplication(directory=self.frontend_dist_dir))
 
     def init_db(self):

--- a/openpectus/aggregator/aggregator_server.py
+++ b/openpectus/aggregator/aggregator_server.py
@@ -60,7 +60,6 @@ class AggregatorServer:
         self.fastapi.add_middleware(database.DBSessionMiddleware)
 
     def start(self):
-        print(f"Serving frontend at http://{self.host}:{self.port}")
         uvicorn.run(self.fastapi, host=self.host, port=self.port, log_level=logging.WARNING)
 
     async def on_shutdown(self):

--- a/openpectus/aggregator/alembic.ini
+++ b/openpectus/aggregator/alembic.ini
@@ -60,7 +60,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = sqlite:///%(here)s/data/aggregator_data.db
+#sqlalchemy.url = sqlite:///%(here)s/data/aggregator_data.db
 
 
 [post_write_hooks]

--- a/openpectus/aggregator/deps.py
+++ b/openpectus/aggregator/deps.py
@@ -17,5 +17,5 @@ def _create_aggregator(dispatcher: AggregatorDispatcher, publisher: FrontendPubl
         return _server
     else:
         _server = Aggregator(dispatcher, publisher)
-        print("GLOBAL: Creating aggregator server")
+        # print("GLOBAL: Creating aggregator server")
         return _server

--- a/openpectus/aggregator/main.py
+++ b/openpectus/aggregator/main.py
@@ -36,9 +36,18 @@ def get_args():
 
 
 def main():
+    title = "Open Pectus Aggregator"
     args = get_args()
-    title = "OpenPectus Aggregator"
-    print(f"*** {title} v. {__version__}, build: {build_number} ***")
+    logger.info(f"Starting {title} v. {__version__}, build: {build_number}")
+    logger.info(f"Serving frontend at http://{args.host}:{args.port}")
+    if os.getenv("SENTRY_DSN"):
+        logger.info(f"Sentry is active with DSN={os.getenv('SENTRY_DSN')}")
+    else:
+        logger.info("Sentry is not active.")
+    if os.getenv("ENABLE_AZURE_AUTHENTICATION", default="").lower() == "true":
+        logger.info(f"Authentication is active.")
+    else:
+        logger.info("Authentication is not active.")
     sentry.init_aggregator(args.sentry_event_level)
     alembic_ini_file_path = os.path.join(os.path.dirname(__file__), "alembic.ini")
     alembic_config = Config(alembic_ini_file_path)

--- a/openpectus/aggregator/main.py
+++ b/openpectus/aggregator/main.py
@@ -22,11 +22,11 @@ logging.getLogger("openpectus.protocol.aggregator_dispatcher").setLevel(logging.
 def get_args():
     parser = ArgumentParser("Start Aggregator server")
     parser.add_argument("-host", "--host", required=False, default=AggregatorServer.default_host,
-                        help="Host address to bind frontend and web socket to")
+                        help=f"Host address to bind frontend and WebSocket to. Default: {AggregatorServer.default_host}")
     parser.add_argument("-p", "--port", required=False, type=int, default=AggregatorServer.default_port,
-                        help="Host port to bind frontend and web socket to")
+                        help=f"Host port to bind frontend and WebSocket to. Default: {AggregatorServer.default_port}")
     parser.add_argument("-fdd", "--frontend_dist_dir", required=False, default=AggregatorServer.default_frontend_dist_dir,
-                        help="Frontend distribution directory. Defaults to " + AggregatorServer.default_frontend_dist_dir)
+                        help=f"Frontend distribution directory. Default: {AggregatorServer.default_frontend_dist_dir}")
     parser.add_argument("-sev", "--sentry_event_level", required=False,
                         default=sentry.EVENT_LEVEL_DEFAULT, choices=sentry.EVENT_LEVEL_NAMES,
                         help=f"Minimum log level to send as sentry events. Default: '{sentry.EVENT_LEVEL_DEFAULT}'")

--- a/openpectus/aggregator/routers/auth.py
+++ b/openpectus/aggregator/routers/auth.py
@@ -21,11 +21,6 @@ client_id = os.getenv('AZURE_APPLICATION_CLIENT_ID', default=None)
 # authorization_url = f'https://login.microsoftonline.com/{tenant_id}/oauth2/authorize'
 jwks_url = 'https://login.microsoftonline.com/common/discovery/keys'
 
-if use_auth:
-    print("Authentication enabled")
-else:
-    print("Authentication disabled")
-
 
 @router.get('/config')
 def get_config() -> AuthConfig:

--- a/openpectus/frontend/openapi.json
+++ b/openpectus/frontend/openapi.json
@@ -1,8 +1,12 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Pectus Aggregator",
-    "version": "0.1.0"
+    "title": "Open Pectus Aggregator",
+    "contact": {
+      "name": "Open Pectus",
+      "url": "https://github.com/Open-Pectus/Open-Pectus"
+    },
+    "version": "0.1.13"
   },
   "paths": {
     "/api/process_unit/{unit_id}": {

--- a/openpectus/frontend/src/app/api/core/OpenAPI.ts
+++ b/openpectus/frontend/src/app/api/core/OpenAPI.ts
@@ -47,7 +47,7 @@ export const OpenAPI: OpenAPIConfig = {
 	PASSWORD: undefined,
 	TOKEN: undefined,
 	USERNAME: undefined,
-	VERSION: '0.1.0',
+	VERSION: '0.1.13',
 	WITH_CREDENTIALS: false,
 	interceptors: {
 		response: new Interceptors(),

--- a/openpectus/sentry.py
+++ b/openpectus/sentry.py
@@ -85,10 +85,6 @@ def init_engine(event_level_name: str):
 
     - Attaches tag component='engine' to all events
     """
-    if os.getenv('SENTRY_DSN'):
-        print("Sentry is active")
-    else:
-        print("Sentry is not active")
 
     event_level_int = _get_event_level_from_name(event_level_name)
 


### PR DESCRIPTION
The database affords us persistence but it is quite difficult to persist using our Docker image since the database is saved in the `openpectus` install directory under `site-packages`.

I have added the path as an argument to the `pectus-aggregator` command and changed the default to be the current directory that the command is called from.

I couldn't help myself so I did a little bit of housekeeping as well:
* Getting rid of prints related to `aggregator/main.py` and replacing them with log statements instead
* Add version and contact info to FastAPI
* Add default value to help text for `pectus-aggregator` command