### PR TITLE
623 dispatcher not closed on engine shutdown

### DIFF
--- a/openpectus/engine/engine_runner.py
+++ b/openpectus/engine/engine_runner.py
@@ -381,7 +381,7 @@ class EngineRunner(EventListener):
                             messages.append(self._message_builder.create_runlog_msg(self.run_id))
                     except Exception:
                         logger.error("Exception occurred building messages", exc_info=True)
-    
+
                     for msg in messages:
                         if msg is not None:
                             await self._post_async(msg)

--- a/openpectus/engine/engine_runner.py
+++ b/openpectus/engine/engine_runner.py
@@ -146,7 +146,7 @@ class EngineRunner(EventListener):
 
     async def _disconnect_async(self, set_state_disconnected=True):
         if self.state == "Stopped":
-            return
+            pass
         elif self.state == "Failed":
             pass
         else:

--- a/openpectus/engine/engine_runner.py
+++ b/openpectus/engine/engine_runner.py
@@ -97,14 +97,12 @@ class EngineRunner(EventListener):
         assert self.run_id is not None
         run_id = self.run_id
         super().on_stop()
-
-        if True or self.state == "Connected" or self.state == "Reconnected":
-            msg = self._message_builder.create_run_stopped_msg(run_id)
-            try:
-                self.post(msg)
-            except Exception:
-                logger.warning("Failed to send RunStoppedMsg, adding to buffer")
-                self._buffer_message(msg)
+        msg = self._message_builder.create_run_stopped_msg(run_id)
+        try:
+            self.post(msg)
+        except Exception:
+            logger.warning("Failed to send RunStoppedMsg, adding to buffer")
+            self._buffer_message(msg)
 
     @property
     def state(self) -> RecoverState:
@@ -398,4 +396,4 @@ class EngineRunner(EventListener):
         self._state_task = asyncio.create_task(send_messages(), name="engine.engine_runner.on_steady_state.send_messages")
 
     def __str__(self) -> str:
-        return f"EngineDispatcherErrorRecoveryDecorator(state: {self.state})"
+        return f"EngineRunner(state: {self.state})"

--- a/openpectus/engine/engine_runner.py
+++ b/openpectus/engine/engine_runner.py
@@ -254,7 +254,10 @@ class EngineRunner(EventListener):
             else:
                 logger.debug("Cancelling state task " + self._state_task.get_name())
                 self._state_task.cancel()
-                await self._state_task  # Await cancellation
+                try:
+                    await self._state_task  # Await cancellation
+                except asyncio.CancelledError:
+                    pass
                 self._state_task = None
 
         if state == "Connected":
@@ -385,6 +388,7 @@ class EngineRunner(EventListener):
                     for msg in messages:
                         if msg is not None:
                             await self._post_async(msg)
+                    await asyncio.sleep(0.3)
             except asyncio.CancelledError:
                 logger.info("Cancelled _state_task")
             except Exception:

--- a/openpectus/engine/engine_runner.py
+++ b/openpectus/engine/engine_runner.py
@@ -175,9 +175,9 @@ class EngineRunner(EventListener):
         states_to_post: list[RecoverState] = ["Connected", "Reconnected"]
         assert self.state in states_to_post, f"Invalid Post state for message: {message.ident}"
 
-        task = asyncio.create_task(self._dispatcher.send_async(message), name="engine.engine_runner.post")
+        task = asyncio.run_coroutine_threadsafe(self._dispatcher.send_async(message), self._loop)
         while not task.done():
-            time.sleep(0.2)
+            time.sleep(0.01)
         ex = task.exception()
         if ex is None:
             return M.SuccessMessage()

--- a/openpectus/protocol/aggregator_dispatcher.py
+++ b/openpectus/protocol/aggregator_dispatcher.py
@@ -132,7 +132,7 @@ class AggregatorDispatcher():
                 await channel.close()
                 return
 
-            logger.info(f"Engine '{engine_id}' connected")
+            logger.info(f"Engine connected: '{engine_id}'")
             self._engine_id_channel_map[engine_id] = channel
 
             if self._connect_handler is not None:

--- a/openpectus/protocol/aggregator_dispatcher.py
+++ b/openpectus/protocol/aggregator_dispatcher.py
@@ -46,6 +46,7 @@ class AggregatorDispatcher():
         self._disconnect_handler: EngineDisconnectHandler | None = None
         self.router = APIRouter(tags=["aggregator"])
         self._engine_id_channel_map: dict[str, RpcChannel] = {}
+        self._on_client_connect_tasks = set()
         # WebsockeRPCEndpoint has wrong types for its on_connect and on_disconnect.
         # It should be List[Callable[[RpcChannel], Awaitable[Any]]] instead of List[Coroutine]
         # See https://github.com/permitio/fastapi_websocket_rpc/issues/30
@@ -145,7 +146,9 @@ class AggregatorDispatcher():
 
     async def on_client_connect(self, channel: RpcChannel):
         channel.default_response_timeout = WEBSOCKET_RPC_TIMEOUT_SECS
-        asyncio.create_task(self._on_delayed_client_connect(channel))
+        task = asyncio.create_task(self._on_delayed_client_connect(channel))
+        self._on_client_connect_tasks.add(task)
+        task.add_done_callback(self._on_client_connect_tasks.discard)
 
     async def on_client_disconnect(self, channel: RpcChannel):
         engine_id: str | None = None

--- a/openpectus/test/integration/test_startup_connection.py
+++ b/openpectus/test/integration/test_startup_connection.py
@@ -1,0 +1,98 @@
+import logging
+import os
+from subprocess import Popen, STDOUT
+import time
+from typing import Any
+import unittest
+import tempfile
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+class ConsoleAppRunner():
+    def __init__(self, program: str, args: list[str]) -> None:
+        self.program = program
+        tempfile.mktemp()
+        self.logfile_name = tempfile.NamedTemporaryFile(suffix=".log").name
+        logger.debug(f"Using temp file {self.logfile_name}")
+        self.process: Popen[Any] | None = None
+        self.args = args
+        self.lines: list[str] = []
+
+    def __enter__(self):
+        return self
+
+    def start(self):
+        self.logfile = open(self.logfile_name, "wb")
+        args = [self.program] + self.args
+        self.process = Popen(args, stdout=self.logfile, stderr=STDOUT, encoding="utf-8")
+
+    @property
+    def output(self) -> str:
+        with open(self.logfile_name, "r") as reader:
+            lines = reader.readlines()
+            return "\n".join(lines)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.process:
+            logger.debug("Killing process")
+            self.process.kill()
+        try:
+            self.logfile.close()
+        except Exception:
+            logger.error("Failed to close file")
+        if os.path.exists(self.logfile_name):
+            time.sleep(1)
+            os.unlink(self.logfile_name)
+
+
+port = "8727"
+
+class TestStartupConnection(unittest.TestCase):
+
+    def assertHasOutput(self, runner: ConsoleAppRunner, expected_text: str, timeout_secs=5):
+        output = runner.output
+        if expected_text in output:
+            return
+        end_time = time.time() + timeout_secs
+        while time.time() < end_time:
+            output = runner.output
+            if expected_text in output:
+                return
+            time.sleep(0.5)
+
+        raise AssertionError(f"Expected text '{expected_text}' was not found in output",
+                             f"Output is: {output}")
+
+    def test_engine_can_connect_to_running_aggregator(self):
+        with ConsoleAppRunner("pectus-aggregator", ["--port", port]) as aggregator, \
+             ConsoleAppRunner("pectus-engine", ["--aggregator_port", port]) as engine:
+
+            aggregator.start()
+            self.assertHasOutput(aggregator, "Starting Open Pectus Aggregator")
+
+            engine.start()
+            self.assertHasOutput(engine, "Registering for engine id")
+
+            self.assertHasOutput(aggregator, "Engine connected", 3)
+            self.assertHasOutput(engine, "Changing state: Started -> Connected", 3)
+            self.assertHasOutput(engine, "Starting engine on first steady-state", 3)
+
+
+    def test_engine_can_connect_to_aggregator_started_after_engine(self):
+        with ConsoleAppRunner("pectus-aggregator", ["--port", port]) as aggregator, \
+             ConsoleAppRunner("pectus-engine", ["--aggregator_port", port]) as engine:
+
+            engine.start()
+            time.sleep(5)
+            self.assertHasOutput(engine, "Registering for engine id")
+
+            aggregator.start()
+            time.sleep(5)
+            self.assertHasOutput(aggregator, "Starting Open Pectus Aggregator")
+
+            time.sleep(2)
+            self.assertHasOutput(aggregator, "Engine connected")
+            self.assertHasOutput(engine, "Changing state: CatchingUp -> Reconnected")
+            self.assertHasOutput(engine, "Starting engine on first steady-state")

--- a/openpectus/test/integration/test_startup_connection.py
+++ b/openpectus/test/integration/test_startup_connection.py
@@ -49,6 +49,19 @@ class ConsoleAppRunner():
 
 port = "8727"
 
+def get_demo_uod_path() -> str:
+    uod_file_path = os.path.join(
+        os.path.dirname(  # openpectus
+            os.path.dirname(  # openpectus/test
+                os.path.dirname(__file__)  # openpectus/test/engine
+            )
+        ),
+        'engine',  # openpectus/engine
+        'configuration',  # openpectus/engine/configuration
+        'demo_uod.py',  # openpectus/engine/configuration/demo_uod.py
+    )
+    return uod_file_path
+
 class TestStartupConnection(unittest.TestCase):
 
     def assertHasOutput(self, runner: ConsoleAppRunner, expected_text: str, timeout_secs=5):
@@ -67,7 +80,7 @@ class TestStartupConnection(unittest.TestCase):
 
     def test_engine_can_connect_to_running_aggregator(self):
         with ConsoleAppRunner("pectus-aggregator", ["--port", port]) as aggregator, \
-             ConsoleAppRunner("pectus-engine", ["--aggregator_port", port]) as engine:
+             ConsoleAppRunner("pectus-engine", ["--aggregator_port", port, "--uod", get_demo_uod_path()]) as engine:
 
             aggregator.start()
             self.assertHasOutput(aggregator, "Starting Open Pectus Aggregator")
@@ -82,7 +95,7 @@ class TestStartupConnection(unittest.TestCase):
 
     def test_engine_can_connect_to_aggregator_started_after_engine(self):
         with ConsoleAppRunner("pectus-aggregator", ["--port", port]) as aggregator, \
-             ConsoleAppRunner("pectus-engine", ["--aggregator_port", port]) as engine:
+             ConsoleAppRunner("pectus-engine", ["--aggregator_port", port, "--uod", get_demo_uod_path()]) as engine:
 
             engine.start()
             time.sleep(5)


### PR DESCRIPTION
Changes:
* `engine_runner` `AsyncTimer` can now be cancelled.
* Websocket can be disconnected when Engine is in `Stopped` state
* `state_task` in `engine_runner` is cancelled on shutdown of the `engine_runner`
* Client connection tasks in `aggregator_dispatch` are properly referenced

With these changes it is possible to shut down an engine flawlessly when running aggregator and engine on the same machine.

Somehow, the TCP socket carrying the WebSocket is not properly released when the async WebSocket client disconnects.
Adding a `transport.abort()` just after the closing WebSocket frame is sent in the `websockets.connection` module fixes the issue, but I consider this to be a hack.

I have attempted to run the following setups:
1. Engine on dev PC, aggregator in cloud behing nginx with SSL
2. Engine on dev PC, aggregator in cloud behing nginx without SSL
3. Engine on dev PC, aggregator in cloud without nginx

All three setups fail in the same way so I am pretty confident the problem is somewhere in the Open Pectus code.
This suspicion is supported by an observation that examples from the `fastapi_websocket_rpc` work just fine running in any of the three setups and doesn't exhibit the problems that our code does.

Thankfully the `engine_dispatcher` and `aggregator_dispatcher` modules are short and concise. I will hunt further and share my findings along the way.

**Update**
Changes to `engine_runner` has fixed the shutdown issue. The primary changes are
1. Let tasks handle the `asyncio.CancelledError` exception.
2. Cancel tasks and wait for tasks to actually cancel
3. Add new `RecoverState` called `ShutdownComplete` and let `run`-method finish when this state is reached.

I consider this task to be solved.