### PR TITLE
207 updating engine while running

### DIFF
--- a/openpectus/engine/archiver.py
+++ b/openpectus/engine/archiver.py
@@ -46,6 +46,19 @@ TagsAccessor = Callable[[], TagCollection]
 
 
 class ArchiverTag(Tag):
+    def __getstate__(self):
+        keys = [
+        'data_path',
+        'last_save_tick',
+        'data_log_interval_seconds',
+        'file_path',
+        'file_ready',
+        'value',
+        'name',
+        'tick_time',
+        ]
+        state = {key: getattr(self, key) for key in keys}
+        return state
     def __init__(self,
                  runlog_accessor: RunlogAccessor,
                  tags_accessor: TagsAccessor,

--- a/openpectus/engine/internal_commands.py
+++ b/openpectus/engine/internal_commands.py
@@ -10,6 +10,12 @@ logger = logging.getLogger(__name__)
 
 
 class InternalCommandsRegistry:
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Don't pickle baz
+        del state["_command_map"]
+        return state
+
     def __init__(self, engine):
         self.engine = engine
         self._command_map: dict[str, Callable[[], InternalEngineCommand]] = {}

--- a/openpectus/engine/main.py
+++ b/openpectus/engine/main.py
@@ -104,6 +104,7 @@ async def main_async(args, loop: asyncio.AbstractEventLoop):
     if args.resume_from_pickle and os.path.isfile("engine_state.pickle"):
         with open("engine_state.pickle", "rb") as f:
             engine = pickle.load(f)
+            assert isinstance(engine, Engine)
             uod = engine.uod
             logger.info("Loaded state from pickle")
     else:
@@ -138,7 +139,10 @@ async def main_async(args, loop: asyncio.AbstractEventLoop):
     message_builder = EngineMessageBuilder(engine)
     # create runner that orchestrates the error recovery mechanism
     runner = EngineRunner(dispatcher, message_builder, engine.emitter, loop)
-    runner.run_id = engine.uod.system_tags.get(SystemTagName.RUN_ID).value
+    assert engine.uod.system_tags is not None
+    run_id = engine.uod.system_tags.get(SystemTagName.RUN_ID).value
+    assert isinstance(run_id, str)
+    runner.run_id = run_id
     _ = EngineMessageHandlers(engine, dispatcher)
 
     # TODO Possibly check dispatcher.check_aggregator_alive() and exit early

--- a/openpectus/engine/main.py
+++ b/openpectus/engine/main.py
@@ -73,6 +73,8 @@ def get_arg_parser():
     parser.add_argument("-sev", "--sentry_event_level", required=False,
                         default=sentry.EVENT_LEVEL_DEFAULT, choices=sentry.EVENT_LEVEL_NAMES,
                         help=f"Minimum log level to send as sentry events. Default is '{sentry.EVENT_LEVEL_DEFAULT}'")
+    parser.add_argument("-r", "--resume_from_pickle", action=BooleanOptionalAction,
+                        help=f"Flag to disable resuming from pickle'")
     return parser
 
 
@@ -99,10 +101,11 @@ def run_validations(uod: UnitOperationDefinitionBase) -> bool:
 async def main_async(args, loop: asyncio.AbstractEventLoop):
     global engine, runner
 
-    if os.path.isfile("engine_state.pickle"):
+    if args.resume_from_pickle and os.path.isfile("engine_state.pickle"):
         with open("engine_state.pickle", "rb") as f:
             engine = pickle.load(f)
             uod = engine.uod
+            logger.info("Loaded state from pickle")
     else:
         try:
             uod = create_uod(args.uod)

--- a/openpectus/engine/main.py
+++ b/openpectus/engine/main.py
@@ -141,8 +141,8 @@ async def main_async(args, loop: asyncio.AbstractEventLoop):
     runner = EngineRunner(dispatcher, message_builder, engine.emitter, loop)
     assert engine.uod.system_tags is not None
     run_id = engine.uod.system_tags.get(SystemTagName.RUN_ID).value
-    assert isinstance(run_id, str)
-    runner.run_id = run_id
+    if isinstance(run_id, str):
+        runner.run_id = run_id
     _ = EngineMessageHandlers(engine, dispatcher)
 
     # TODO Possibly check dispatcher.check_aggregator_alive() and exit early

--- a/openpectus/engine/method_model.py
+++ b/openpectus/engine/method_model.py
@@ -14,7 +14,13 @@ def parse_pcode(pcode: str) -> PProgram:
     return p.build_model()
 
 
-class MethodModel():
+class MethodModel:
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Don't pickle baz
+        del state["_method_init_callback"]
+        del state["_method_error_callback"]
+        return state
     """ Manages the mutable method state and its changes.
 
     Method state is mutated by engine as the program runs, e.g. executed lines are updated

--- a/openpectus/engine/method_model.py
+++ b/openpectus/engine/method_model.py
@@ -17,10 +17,11 @@ def parse_pcode(pcode: str) -> PProgram:
 class MethodModel:
     def __getstate__(self):
         state = self.__dict__.copy()
-        # Don't pickle baz
+        # Don't pickle callbacks
         del state["_method_init_callback"]
         del state["_method_error_callback"]
         return state
+
     """ Manages the mutable method state and its changes.
 
     Method state is mutated by engine as the program runs, e.g. executed lines are updated

--- a/openpectus/lang/exec/pinterpreter.py
+++ b/openpectus/lang/exec/pinterpreter.py
@@ -151,6 +151,28 @@ GenerationType = Generator[None, None, None] | None
 
 
 class PInterpreter(PNodeVisitor):
+    def __getstate__(self):
+        # print(list(self.__dict__.keys()))
+        keys = [
+            '_program',
+            'context',
+            'stack',
+            'interrupts',
+            'running',
+            'start_time',
+            '_tick_time',
+            '_tick_number',
+            #'process_instr',
+            'runtimeinfo'
+        ]
+        # process_instr contains a generator which cannot be pickled.
+        state = {key: getattr(self, key) for key in keys}
+        return state
+
+    def __setstate__(self, state):
+        self.__init__(state["_program"], state["context"])
+        self.__dict__.update(state)
+
     def __init__(self, program: PProgram, context: InterpreterContext) -> None:
         self._program = program
         self.context = context

--- a/openpectus/lang/exec/tags.py
+++ b/openpectus/lang/exec/tags.py
@@ -119,6 +119,13 @@ class Tag(ChangeSubject, EventListener):
 
     Supports lifetime notification events that are automatically invoked by the engine.
     """
+    def __getstate__(self):
+        print('>', self.name)
+        return dict(
+            name = self.name,
+            tick_time = self.tick_time,
+            value = self.value,
+        )
     def __init__(
             self,
             name: str,

--- a/openpectus/lang/exec/timer.py
+++ b/openpectus/lang/exec/timer.py
@@ -31,6 +31,11 @@ class NullTimer(EngineTimer):
 
 
 class OneThreadTimer(EngineTimer):
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Don't pickle baz
+        del state["thread"]
+        return state
     """ Single threaded (1 extra thread) timer.
 
     This allows controlled multithreading.

--- a/openpectus/lang/exec/uod.py
+++ b/openpectus/lang/exec/uod.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 class UnitOperationDefinitionBase:
     """ Represets the Unit Operation Definition interface used by the OpenPectus engine.
     """
+    def __getstate__(self):
+        return dict(filename=self.filename, tags=self.tags, system_tags=self.system_tags)
     def __init__(self,
                  instrument_name: str,
                  hwl: HardwareLayerBase,


### PR DESCRIPTION
Update a running engine by pickling on shutdown and loading the pickle on start.

Missing:
* Interpreter is implemented as generator. Generators cannot be pickled so interpreter state cannot be restored.
* Method cannot be sent from engine to aggregator so it does not show up in the aggregator. It does run from line 1 on start up though.

An alternative to loading state from a pickle (reconstructing internal state) could be to keep track of inputs. If all inputs to the engine are known then it should be possible to replay the input and obtain an identical output state.

I have not attempted this, but it could be done by:
* Keeping track of incoming messages from the aggregator:
Save a list of messages passed to `openpectus.engine.engine_dispatcher` method `dispatch_message_async`.
* Use run log data to visit nodes in the AST and run injected commands.