### PR TITLE
Don't cache /docs

### DIFF
--- a/frontend/ngsw-config.json
+++ b/frontend/ngsw-config.json
@@ -26,5 +26,8 @@
         ]
       }
     }
+  ],
+  "navigationUrls": [
+    "!/docs"
   ]
 }


### PR DESCRIPTION
This PR allows access to docs.
See current behaviour by navigating to https://github.openpectus.org/docs