### PR TITLE
Create dict on UodCommand to hold state

### DIFF
--- a/openpectus/lang/exec/uod.py
+++ b/openpectus/lang/exec/uod.py
@@ -471,6 +471,7 @@ class UodCommand(ContextEngineCommand[UnitOperationDefinitionBase]):
         self.finalize_fn: FINAL_FN | None = None
         self.arg_parse_fn: PARSE_FN | None = None
         self._performance_warned = False
+        self.cmd_state: dict[str, Any] = dict()
 
     @staticmethod
     def builder() -> UodCommandBuilder:


### PR DESCRIPTION
Commands can be expected to contain some state which should be kept around between calls to the `exec_fn`. `cmd_state` attribute can be used for this purpose.