### PR TITLE
Don't show the user an error message when getting 404 on graph.micros…

### DIFF
--- a/frontend/src/app/shared/interceptors/http-error.interceptor.ts
+++ b/frontend/src/app/shared/interceptors/http-error.interceptor.ts
@@ -7,6 +7,13 @@ export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
   const toastr = inject(ToastrService);
   return next(req).pipe(tap({
     error: (error: HttpErrorResponse) => {
+      // some users don't have a profile picture and trying to fetch one will give 404. We don't want to bother the user with an error message in this case
+      if(error.url?.startsWith('https://graph.microsoft.com/')
+         && error.url?.endsWith('/photos/48x48/$value')
+         && error.status === 404) {
+        return;
+      }
+
       const endpoint = error.url?.split('/').at(-1);
       toastr.error(error.error.message, `HTTP Error "${error.statusText}" on endpoint "${endpoint}"`, {
         timeOut: 1000 * 30,

--- a/frontend/src/msw/handlers.ts
+++ b/frontend/src/msw/handlers.ts
@@ -1168,8 +1168,10 @@ Some;Csv;Data
     return new HttpResponse();
   }),
 
-  http.get('/api/process_unit/:unitId/other_active_users', () => {
-    return HttpResponse.json<ActiveUser[]>([]);
+  http.get('/api/process_unit/:unitId/active_users', () => {
+    return HttpResponse.json<ActiveUser[]>([
+      {id: 'fdsa', name: 'fdsa'},
+    ]);
   }),
 
   http.get('api/lsp/engine/:unitId/pcode.tmLanguage.json', () => {
@@ -1215,4 +1217,12 @@ Some;Csv;Data
       ],
     });
   }),
+
+  http.get('https://graph.microsoft.com/beta/users/:userId/photos/48x48/$value', () => {
+    return new HttpResponse(null, {status: 404});
+  }),
+
+  // http.get('https://graph.microsoft.com/beta/me/photos/48x48/$value', () => {
+  //   return new HttpResponse(null, {status: 404});
+  // }),
 ];


### PR DESCRIPTION
…oft photo endpoints

Some users just don't have a profile picture, and trying to fetch theirs gives 404. We don't want to bother the user in that case.