### PR TITLE
Make run log line state-based bg coloring more explicit

### DIFF
--- a/frontend/src/app/details/run-log/run-log-line/run-log-line.component.ts
+++ b/frontend/src/app/details/run-log/run-log-line/run-log-line.component.ts
@@ -12,22 +12,22 @@ import { RunLogLineForceButtonComponent } from './run-log-line-force-button.comp
 import { RunLogLineProgressComponent } from './run-log-line-progress.component';
 
 @Component({
-    selector: 'app-run-log-line',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [
-        LetDirective,
-        NgIf,
-        RunLogLineProgressComponent,
-        RunLogLineForceButtonComponent,
-        RunLogLineCancelButtonComponent,
-        RunLogAdditionalValuesComponent,
-        DatePipe,
-    ],
-    template: `
+  selector: 'app-run-log-line',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    LetDirective,
+    NgIf,
+    RunLogLineProgressComponent,
+    RunLogLineForceButtonComponent,
+    RunLogLineCancelButtonComponent,
+    RunLogAdditionalValuesComponent,
+    DatePipe,
+  ],
+  template: `
     <div [class.bg-slate-50]="rowIndex % 2 === 0"
          [class.bg-slate-100]="rowIndex % 2 === 1"
-         [class.!bg-yellow-100]="runLogLine?.forced"
-         [class.!bg-red-200]="runLogLine?.cancelled"
+         [class.!bg-yellow-100]="runLogLine?.forced && !runLogLine?.cancelled && !runLogLine?.failed"
+         [class.!bg-red-200]="runLogLine?.cancelled && !runLogLine?.failed"
          [class.!bg-red-600]="runLogLine?.failed"
          class="border-b-2 border-white cursor-pointer"
          *ngrxLet="expanded as expanded" (click)="toggleCollapse(expanded)">

--- a/frontend/src/msw/handlers.ts
+++ b/frontend/src/msw/handlers.ts
@@ -371,6 +371,7 @@ const runLogLines: RunLogLine[] = [
     cancellable: false,
     forced: false,
     cancelled: true,
+    failed: false,
   },
   {
     id: '4',


### PR DESCRIPTION
To avoid potential future bug when upgrading tailwind