### PR TITLE
Fix accumulated CV failing when CV is 0.0

### DIFF
--- a/openpectus/lang/exec/tags_impl.py
+++ b/openpectus/lang/exec/tags_impl.py
@@ -89,7 +89,10 @@ class AccumulatorTag(Tag):
 
     def on_tick(self, tick_time: float, increment_time: float):
         assert self.v0 is not None, f"Error in aggregator tag '{self.name}', v0 was not set."
-        self.value = self.totalizer.as_float() - self.v0
+        try:
+            self.value = self.totalizer.as_float() - self.v0
+        except ValueError:
+            self.value = 0.0
 
 
 class BlockTimeTag(Tag):


### PR DESCRIPTION
This change ensures that `AccumulatorTag` `on_tick` method does not fail at `as_float` because of None value due to CV being 0.0.