### PR TITLE
Engine restart while run on-going will reset aggregator to No-run state

### DIFF
--- a/openpectus/aggregator/aggregator.py
+++ b/openpectus/aggregator/aggregator.py
@@ -190,13 +190,21 @@ class FromEngine:
                 return
             run_id = engine_data.run_data.run_id if engine_data.has_run() else None
             if run_id is None and msg_run_id is not None:
+                # A run can only be started with an aggregator connected,
+                # so it should not be possible for the aggregator to not
+                # know about a run.
+                # This situation should never happen.
                 logger.error("Skipping tag update message because it belongs to run " +
                              f"'{msg_run_id}' but there is no active run")
                 return
             elif run_id is not None and msg_run_id is None:
-                logger.error("Skipping tag update message because it belongs to run " +
-                             f"'{msg_run_id}' but the current run is '{run_id}'")
-                return
+                # If the aggregator knows about the run, but the engine doesn't
+                # then that indicates that the engine process was restarted.
+                # In that case, archive the run and move on.
+                recent_run_repo = RecentRunRepository(database.scoped_session())
+                recent_run_repo.store_recent_run(engine_data)
+                logger.info(f"Engine appears to have been reset. Storing run_id {run_id}.")
+                engine_data.reset_run()
 
             for changed_tag_value in changed_tag_values:
                 if changed_tag_value.name == SystemTagName.METHOD_STATUS.value and engine_data.has_run():

--- a/openpectus/engine/engine_message_builder.py
+++ b/openpectus/engine/engine_message_builder.py
@@ -113,9 +113,9 @@ class EngineMessageBuilder():
             pass
         return [tag for tag in tags.values()]
 
-    def create_tag_updates_snapshot_msg(self) -> EM.TagsUpdatedMsg:
+    def create_tag_updates_snapshot_msg(self, run_id: str | None) -> EM.TagsUpdatedMsg:
         tags = self.collect_tag_updates(snapshot=True)
-        return EM.TagsUpdatedMsg(tags=tags)
+        return EM.TagsUpdatedMsg(tags=tags, run_id=run_id)
 
     def create_tag_updates_msg(self, run_id: str | None) -> EM.TagsUpdatedMsg | None:
         tags = self.collect_tag_updates()

--- a/openpectus/engine/engine_runner.py
+++ b/openpectus/engine/engine_runner.py
@@ -402,7 +402,7 @@ class EngineRunner(EventListener):
 
     async def steady_state_send_messages(self):
         logger.info("Started steady-state sending loop")
-        await self._post_async(self._message_builder.create_tag_updates_snapshot_msg())
+        await self._post_async(self._message_builder.create_tag_updates_snapshot_msg(self.run_id))
         while self._state_task and self._state_task.cancelling() == 0:
             messages = []
             try:


### PR DESCRIPTION
We have the infrastructure in place to handle:
* Interruptions to engine-aggregator connection.
* Sudden restart of aggregator with running engines.
* Sudden restart of engine connected to aggregator.

What we apparently don't handle is the case that a `Running` engine, connected to an aggregator, is killed and started again from scratch (`Stopped` state). In this case, the aggregator will not accept data from the engine because the aggregator expects data from the run from before the engine was killed.
To get into a congruent state the user has to `Start` a run and then `Stop` it again.

This PR introduces logic such that the aggregator can correctly archive the old run and synchronize with the engine as it reconnects and sends data with `run_id=None`.