### PR TITLE
Fix plot resetting on page reload

### DIFF
--- a/frontend/src/app/details/ngrx/details.actions.ts
+++ b/frontend/src/app/details/ngrx/details.actions.ts
@@ -18,6 +18,9 @@ export class DetailsActions {
   static commandExamplesFetched = createAction(source + 'Command Examples Fetched', props<{ commandExamples: CommandExample[] }>());
   static commandsComponentExecuteClicked = createAction(source + 'Commands Component Execute Clicked', props<{ command: ExecutableCommand }>());
   static controlStateFetched = createAction(source + 'Control State Fetched', props<{ controlState: ControlState }>());
+  static controlStateFetchedFromUpdate = createAction(source + 'Control State Fetched From Update', props<{ controlState: ControlState }>());
+  static controlStateChanged = createAction(source + 'Control State Changed',
+    props<{ oldControlState: ControlState, newControlState: ControlState }>());
   static controlCommandExecutionFailed = createAction(source + 'Control Command Execution Failed');
   static controlCommandExecutionSucceeded = createAction(source + 'Control Command Execution Succeeded');
   static recentRunDetailsInitialized = createAction(source + 'Recent Run Details Initialized');
@@ -32,6 +35,4 @@ export class DetailsActions {
   static processUnitNavigatedFrom = createAction(source + 'Process Unit Navigated From', props<{ oldUnitId?: string, newUnitId?: string }>());
   static otherActiveUsersFetched = createAction(source + 'Other Active Users Fetched', props<{ otherActiveUsers: ActiveUser[] }>());
   static activeUsersUpdatedOnBackend = createAction(source + 'Active Users Updated On Backend', props<{ unitId: string }>());
-  static controlStateChanged = createAction(source + 'Control State Changed',
-    props<{ oldControlState: ControlState, newControlState: ControlState }>());
 }

--- a/frontend/src/app/details/ngrx/details.effects.ts
+++ b/frontend/src/app/details/ngrx/details.effects.ts
@@ -71,7 +71,7 @@ export class DetailsEffects {
     ofType(DetailsActions.controlStateUpdatedOnBackend),
     mergeMap(({unitId}) => {
       return this.processUnitService.getControlState({unitId}).pipe(
-        map(controlState => DetailsActions.controlStateFetched({controlState})),
+        map(controlState => DetailsActions.controlStateFetchedFromUpdate({controlState})),
       );
     }),
   ));
@@ -216,7 +216,7 @@ export class DetailsEffects {
   ));
 
   controlStateChanged = createEffect(() => this.actions.pipe(
-    ofType(DetailsActions.controlStateFetched),
+    ofType(DetailsActions.controlStateFetchedFromUpdate),
     concatLatestFrom(() => this.store.select(DetailsSelectors.previousControlState)),
     switchMap(([{controlState}, previousControlState]) => {
       return of(DetailsActions.controlStateChanged({oldControlState: previousControlState, newControlState: controlState}));

--- a/frontend/src/app/details/ngrx/details.reducer.ts
+++ b/frontend/src/app/details/ngrx/details.reducer.ts
@@ -82,7 +82,7 @@ const reducer = createReducer(initialState,
   on(DetailsActions.commandExamplesFetched, (state, {commandExamples}) => produce(state, draft => {
     draft.commandExamples = commandExamples;
   })),
-  on(DetailsActions.controlStateFetched, (state, {controlState}) => produce(state, draft => {
+  on(DetailsActions.controlStateFetched, DetailsActions.controlStateFetchedFromUpdate, (state, {controlState}) => produce(state, draft => {
     draft.previousControlState = state.controlState;
     draft.controlState = controlState;
     draft.optimisticClickedControlButtons = {start: false, stop: false, pause: false, hold: false};


### PR DESCRIPTION
Handle controla state fetching from initial load more separately from fetching from a websocket notified update, and only reset plot when control state changes to running from an update.